### PR TITLE
Initial 1.19.2 port

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -9,14 +9,14 @@ dependencies {
     // Remove the next line if you don't want to depend on the API
     modApi "dev.architectury:architectury:${rootProject.architectury_version}"
 
-    modApi("org.valkyrienskies:valkyrienskies-118-common:${rootProject.vs2_version}")
+    modApi("org.valkyrienskies:valkyrienskies-1192-common:${rootProject.vs2_version}")
     implementation("org.valkyrienskies.core:api:${rootProject.vs_core_version}") { transitive = false }
 
     api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.21"
     api "org.jetbrains.kotlin:kotlin-reflect:1.7.21"
 
     // CC Restitched
-    modCompileOnly("curse.maven:cc-restitched-462672:3622561")
+    modCompileOnly("curse.maven:cc-restitched-462672:3908334")
 }
 
 architectury {

--- a/common/src/main/kotlin/net/spaceeye/someperipherals/blocks/raycaster/RaycasterBaseBlock.kt
+++ b/common/src/main/kotlin/net/spaceeye/someperipherals/blocks/raycaster/RaycasterBaseBlock.kt
@@ -3,6 +3,7 @@ package net.spaceeye.someperipherals.blocks.raycaster
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
 import net.minecraft.server.level.ServerLevel
+import net.minecraft.util.RandomSource
 import net.minecraft.world.item.context.BlockPlaceContext
 import net.minecraft.world.level.block.BaseEntityBlock
 import net.minecraft.world.level.block.Block
@@ -46,7 +47,7 @@ class RaycasterBaseBlock(properties: Properties): BaseEntityBlock(properties) {
         return RenderShape.MODEL
     }
 
-    override fun tick(state: BlockState, level: ServerLevel, pos: BlockPos, random: Random) {
+    override fun tick(state: BlockState, level: ServerLevel, pos: BlockPos, random: RandomSource) {
         super.tick(state, level, pos, random)
         if (ticks >= SomePeripheralsConfig.SERVER.COMMON.RAYCASTER_SETTINGS.save_cache_for_ticks) {
             pos_cache.clear()

--- a/common/src/main/kotlin/net/spaceeye/someperipherals/items/RangeGogglesItem.kt
+++ b/common/src/main/kotlin/net/spaceeye/someperipherals/items/RangeGogglesItem.kt
@@ -2,7 +2,6 @@ package net.spaceeye.someperipherals.items
 
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.network.chat.Component
-import net.minecraft.network.chat.TranslatableComponent
 import net.minecraft.world.InteractionResult
 import net.minecraft.world.entity.EquipmentSlot
 import net.minecraft.world.item.ArmorItem
@@ -19,7 +18,7 @@ class RangeGogglesItem:
     private val CONTROLLER_LEVEL = "controller_level"
 
     override fun getDescription(): Component {
-        return TranslatableComponent("item.some_peripherals.tootlip.range_goggles")
+        return Component.translatable("item.some_peripherals.tootlip.range_goggles")
     }
 
     override fun useOn(context: UseOnContext): InteractionResult {
@@ -29,7 +28,7 @@ class RangeGogglesItem:
         val entity = level.getBlockEntity(bpos)
         if (entity !is GoggleLinkPortBlockEntity) {return super.useOn(context)}
         if (level.isClientSide) {
-            context.player!!.displayClientMessage(TranslatableComponent("text.some_peripherals.linked_rage_goggles"), true)
+            context.player!!.displayClientMessage(Component.translatable("text.some_peripherals.linked_rage_goggles"), true)
             return InteractionResult.SUCCESS
         }
         val controller: GoggleLinkPortBlockEntity = entity
@@ -41,7 +40,7 @@ class RangeGogglesItem:
         nbt.putString(CONTROLLER_LEVEL, controller.getLevel()?.dimension().toString());
         item.setTag(nbt);
 
-        context.player!!.displayClientMessage(TranslatableComponent("text.some_peripherals.linked_rage_goggles"), true)
+        context.player!!.displayClientMessage(Component.translatable("text.some_peripherals.linked_rage_goggles"), true)
         return InteractionResult.SUCCESS
     }
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionFabric")) { transitive false }
 
-    modApi("org.valkyrienskies:valkyrienskies-118-fabric:${rootProject.vs2_version}") { transitive = false }
+    modApi("org.valkyrienskies:valkyrienskies-1192-fabric:${rootProject.vs2_version}") { transitive = false }
     implementation("org.valkyrienskies.core:api:${rootProject.vs_core_version}") { transitive = false }
 
     // Kotlin
@@ -44,7 +44,7 @@ dependencies {
     api "org.jetbrains.kotlin:kotlin-reflect:1.7.21"
 
     // CC Restitched
-    modImplementation("curse.maven:cc-restitched-462672:3622561")
+    modImplementation("curse.maven:cc-restitched-462672:3908334")
 }
 
 processResources {

--- a/fabric/src/main/java/net/spaceeye/someperipherals/fabric/SomePeripheralsFabric.kt
+++ b/fabric/src/main/java/net/spaceeye/someperipherals/fabric/SomePeripheralsFabric.kt
@@ -1,7 +1,7 @@
 package net.spaceeye.someperipherals.fabric
 
 import net.fabricmc.api.ModInitializer
-import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback
 import net.spaceeye.someperipherals.SomePeripherals
 import net.spaceeye.someperipherals.SomePeripheralsCommands
 
@@ -9,6 +9,6 @@ class SomePeripheralsFabric: ModInitializer {
     override fun onInitialize() {
         SomePeripherals.init()
 
-        CommandRegistrationCallback.EVENT.register { dispatcher, _ -> SomePeripheralsCommands.registerServerCommands(dispatcher)}
+        CommandRegistrationCallback.EVENT.register { dispatcher, registryAccess, environment -> SomePeripheralsCommands.registerServerCommands(dispatcher)}
     }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -6,7 +6,7 @@
   "name": "Some Peripherals",
   "description": "",
   "authors": ["SpaceEye"],
-  "contributors": ["Illuc", "Tetrode"],
+  "contributors": ["Illuc", "Tetrode", "sashafiesta"],
   "contact": {},
 
   "license": "MIT",
@@ -25,7 +25,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.14.22",
-    "minecraft": ">=1.18",
+    "minecraft": ">=1.19",
     "fabric-language-kotlin": ">=1.10.10+kotlin.1.9.10"
   }
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     // Remove the next line if you don't want to depend on the API
     modApi "dev.architectury:architectury-forge:${rootProject.architectury_version}"
 
-    modApi("org.valkyrienskies:valkyrienskies-118-forge:${rootProject.vs2_version}") { transitive = false }
+    modApi("org.valkyrienskies:valkyrienskies-1192-forge:${rootProject.vs2_version}") { transitive = false }
     implementation("org.valkyrienskies.core:api:${rootProject.vs_core_version}") { transitive = false }
 
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
@@ -64,7 +64,7 @@ dependencies {
     implementation 'thedarkcolour:kotlinforforge:3.12.0'
 
     // CC Tweaked
-    modImplementation("curse.maven:cctweaked-282001:4061947")
+    modImplementation("curse.maven:cctweaked-282001:4395619")
 }
 
 processResources {

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -36,7 +36,7 @@ logoFile="icon.png" #optional
 description='''
 
 '''
-authors = "SpaceEye, Illuc, Tetrode"
+authors = "SpaceEye, Illuc, Tetrode, sashafiesta"
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
 [[dependencies.some_peripherals]] #optional
    # the modid of the dependency
@@ -44,7 +44,7 @@ authors = "SpaceEye, Illuc, Tetrode"
    # Does this dependency have to exist - if not, ordering below must be specified
    mandatory=true #mandatory
    # The version range of the dependency
-   versionRange="[38,)" #mandatory
+   versionRange="[41,)" #mandatory
    # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
    ordering="NONE"
    # Side this dependency is applied on - BOTH, CLIENT or SERVER
@@ -54,7 +54,7 @@ authors = "SpaceEye, Illuc, Tetrode"
    modId="minecraft"
    mandatory=true
    # This version range declares a minimum of the current minecraft version up to but not including the next major version
-   versionRange="[1.18,1.19)"
+   versionRange="[1.19,1.20)"
    ordering="NONE"
    side="BOTH"
 [[dependencies.some_peripherals]]

--- a/forge/src/main/resources/pack.mcmeta
+++ b/forge/src/main/resources/pack.mcmeta
@@ -1,8 +1,8 @@
 {
   "pack": {
     "description": "Some-Peripherals resources",
-    "pack_format": 8,
-    "forge:resource_pack_format": 8,
-    "forge:data_pack_format": 9
+    "pack_format": 9,
+    "forge:resource_pack_format": 9,
+    "forge:data_pack_format": 10
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,17 @@
 org.gradle.jvmargs=-Xmx1G
 
-minecraft_version=1.18.2
+minecraft_version=1.19.2
 
 archives_base_name=Some-Peripherals
 mod_version=0.0.4
 maven_group=net.spaceeye
 
-architectury_version=4.11.93
+architectury_version=6.5.85
 
 fabric_loader_version=0.14.22
-fabric_api_version=0.76.0+1.18.2
+fabric_api_version=0.76.1+1.19.2
 
-forge_version=1.18.2-40.2.10
+forge_version=1.19.2-43.3.0
 
-vs2_version=2.1.0-beta.14+acba7d4175
+vs2_version=2.2.0-beta.4+b2de01d9de
 vs_core_version=1.1.0+c92814e9b7


### PR DESCRIPTION
Note that only USED code was ported (I didn't bother to check /common/src/main/kotlin/net/spaceeye/someperipherals/unused_for_now) 0.0.4 features seem to work right now (tested)